### PR TITLE
Fixes #37 - Fix ValueError exception

### DIFF
--- a/error_posts/models.py
+++ b/error_posts/models.py
@@ -46,7 +46,7 @@ class ErrorPost(TimeStampedModel):
             try:
                 clean_traceback(self.traceback)
             except ValueError as e:
-                raise ValidationError({'traceback': e.message})
+                raise ValidationError({'traceback': e})
 
     def _get_raised_by(self):
         last_frame = self.parsed_traceback['frames'][-1]

--- a/error_posts/tests/test_models.py
+++ b/error_posts/tests/test_models.py
@@ -1,0 +1,13 @@
+from django.test import TestCase
+from django.core import exceptions
+
+from error_posts.models import ErrorPost
+
+
+class TestTracebackInvalid(TestCase):
+
+    def test_invalid_traceback_raises_validation_error_on_clean(self):
+
+        with self.assertRaises(exceptions.ValidationError):
+            error_post = ErrorPost(traceback="invalid traceback")
+            error_post.clean()

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
-DJANGO_SETTINGS_MODULE=fix_my_django.settings
+DJANGO_SETTINGS_MODULE=fix_my_django.settings.test
 norecursedirs=*.egg .git venv env tmp* static* media bower_components
 addopts=--reuse-db


### PR DESCRIPTION
* Problem
When submitting an invalid Traceback on error submission, got back a 500 page informing that ValueError had no attribute message.

* Solution
In python3 exception.message was removed, now we just use the exception object.

* How to test it
Submit an invalid traceback on the submission form, it will show a field message.