### PR TITLE
Fix markdown editor not showing in the create Error page

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -31,6 +31,8 @@
     ga('create', 'UA-62218429-1', 'auto');
     ga('send', 'pageview');
   </script>
+  <!-- JQuery must be called before the content block because it must be initialized before django markdown -->
+  <script type="text/javascript" src="{% static 'jquery/dist/jquery.js' %}"></script>
 </head>
 
 <body>
@@ -125,7 +127,6 @@
 
     return t;
   }(document, "script", "twitter-wjs"));</script>
-  <script type="text/javascript" src="{% static 'jquery/dist/jquery.js' %}"></script>
   <script type="text/javascript" src="{% static 'bootstrap-sass/assets/javascripts/bootstrap.js' %}"></script>
   <script type="text/javascript" src="{% static 'select2/dist/js/select2.js' %}"></script>
 

--- a/templates/error_posts/create.html
+++ b/templates/error_posts/create.html
@@ -1,11 +1,14 @@
 {% extends 'base.html' %}
 {% load widget_tweaks %}
+{% load django_markdown %}
 
 {% block title %}
   <title>Fix My Django - Insert an Error</title>
 {% endblock title %}
 
 {% block content %}
+<!-- Load the necessary styles for the markdown editor -->
+{% markdown_media %}
   <div class="row">
     <div class="panel" >
       <div class="panel-create panel-heading">Insert an Error</div>


### PR DESCRIPTION
@fernandolins Helped me and we discovered that the Django-Markdown is working just fine, the problem for the markdow editor not showing was because of jquery and some template tags missing.

Fix that problem and use the Django-Markdown was the simplest solution compared to replace the entire markdown lib.